### PR TITLE
[WIP] Incorporate Acceleration Enhancement Framework with AutoGPTQ and Triton V2 kernels

### DIFF
--- a/fixtures/acceleration_framework.yaml
+++ b/fixtures/acceleration_framework.yaml
@@ -1,0 +1,5 @@
+plugins:
+  peft:
+    quantization: auto_gptq
+    kernel: triton_v2
+    from_quantized: True

--- a/tuning/acceleration/__init__.py
+++ b/tuning/acceleration/__init__.py
@@ -1,0 +1,1 @@
+from .framework import AccelerationFramework

--- a/tuning/acceleration/framework.py
+++ b/tuning/acceleration/framework.py
@@ -2,64 +2,106 @@
 def parse_configuration():
     pass
 
-from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
-from auto_gptq.utils.peft_utils import get_gptq_peft_model
 
 from transformers import TrainingArguments
-from peft import LoraConfig
+from peft import LoraConfig, prepare_model_for_kbit_training
 
 from types import MethodType
+
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+from auto_gptq.utils.peft_utils import get_gptq_peft_model
 from auto_gptq.utils.peft_utils import GPTQLoraModel
+from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as triton_Qlinear
+
+from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
 from peft.tuners.lora.model import LoraModel
+
+from typing import Tuple
 
 import torch
 
 def _replace_module(self, parent_module, child_name, new_module, old_module):
+
+    # replace the lora linear
     setattr(parent_module, child_name, new_module)
-    # dispatch to correct device
+
+    # dispatch to correct device 
+    # FIXME: refactor
     for name, module in new_module.named_modules():
         if "lora_" in name:
             device = (list(old_module.parameters()) + list(old_module.buffers()))[0].device
             module.to(device)
 
-from peft.tuners.lora.gptq import QuantLinear as PEFT_LoraLinear
-
-def _dispatch_gptq_triton(
-    target: torch.nn.Module,
+# def _dispatch_lora_linear_for_gptq(
+def _create_new_module_triton(
+    lora_config: LoraConfig,
     adapter_name: str,
+    target: torch.nn.Module,
     **kwargs,
 ):
+    # if the base layer module matches a supported class, dispatch the lora linear
+    # to be installed
     new_module = None
-    from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as triton_Qlinear
     if isinstance(target, triton_Qlinear):
-        new_module = PEFT_LoraLinear(target, adapter_name, **kwargs)
-    return new_module
+        new_module = LoraLinearGPTQ(target, adapter_name, lora_config=lora_config, **kwargs)
 
-# refactor!
-def _create_new_module_triton(lora_config, adapter_name, target, **kwargs):
-    return _dispatch_gptq_triton(target, adapter_name, lora_config=lora_config, **kwargs)
+    # if module cannot be found, return None which results in a raise in the call-stack
+    return new_module
 
 class AccelerationFramework:
     def __init__(self, configuration_file: str=None):
+
+        # Currently we only support the triton_v2 kernel, so there is nothing
+        # much else to configure
         pass
 
     def model_loader(self, model_name: str, **kwargs):
+
+        # Currently we allow only a quantized checkpoint to be loaded, we do not
+        # implement the quantization process here. 
+        #
+        # The quantization process is used to convert a non-quantized checkpoint
+        # (provided in model_name) into a quantized one. This entails
+        # 1. providing a BaseQuantizeConfig with the appropriate quantization settings
+        # 2. calling BaseGPTQForCausalLM.quantize to run the quantization algorithm (may take time, e.g. hours)
+        # 3. calling BaseGPTQForCausalLM.save_pretrained to save a quantized checkpoint
+        # 
+        # The reasons for not implementing the flow at this point are.
+        # 1. The quantization can take very long for large models. As such, it is more appropriate
+        #    to run it once outside of training, and save the checkpoint to be used for multiple runs.
+        # 2. Requires some API changes to point to where the quantized checkpoint should be saved.
+        #    Can be confusing to the user since it will be different from model_name
+
+        # NOTE: there will be a warning that can be ignored
+        # "WARNING - QuantLinear with the exllama backend not does support the trainable mode yet, switching to cuda/cuda_old/triton backend."
+
+        # assume model_name points to a quantized checkpoint. Thus we load the quantization
+        # config directly from the checkpoint.
         quantize_config = BaseQuantizeConfig.from_pretrained(model_name)
-        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
-        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
 
+        # get additional parameters
         torch_dtype = kwargs.get('torch_dtype', torch.float32)
+        low_cpu_mem_usage = kwargs.get('low_cpu_mem_usage', False)
 
-        return AutoGPTQForCausalLM.from_quantized(
-            model_name, quantize_config = quantize_config,
+        model = AutoGPTQForCausalLM.from_quantized(
+            model_name, 
+            quantize_config=quantize_config,
             torch_dtype=torch_dtype,
-            use_marlin = False,
-            disable_exllama = True,
-            # warmup_triton = True,
-            warmup_triton= False, # disable for now, because it will try to run the warmup while on CPU
-            use_tritonv2 = True,
-            trainable = True,
+            low_cpu_mem_usage=low_cpu_mem_usage,
+            use_marlin=False, # disable, cannot be used for training (no forward+backward)
+            disable_exllama=True, # disable, cannot be used for training (no backward)
+            warmup_triton=False, # disable for now, because it will try to run the warmup while on CPU
+            use_tritonv2=True,
+            trainable=True, # only support trainable mode
         )
+
+        # these will be properly set since it is not loaded using from_pretrained
+        # - so, set them here. 
+        # - in particular "is_loaded_in_4bit" will be checked in prepare_model_for_kbit_training
+        #   and there is a section of code that will be skipped if not set.
+        setattr(model, "is_loaded_in_4bit", True)
+        setattr(model, "quantization_method", 'gptq')
+        return model
 
     @property
     def requires_custom_loading(self):
@@ -72,35 +114,59 @@ class AccelerationFramework:
     def augmentation(
         self, 
         model, 
-        accelerator,
-        train_args: TrainingArguments, 
-        peft_config: LoraConfig,
+        train_args: TrainingArguments,
+        modifiable_args: Tuple[LoraConfig],
     ):
+        peft_config, = modifiable_args # unpack modifiable args
+
+        # some assertions
         assert peft_config is not None, "need peft_config to install PEFT adapters"
+        assert model.dtype == torch.float16 or train_args.fp16,\
+             "need to run in fp16 mixed precision or load model in fp16"
 
-        # FIXME: handle this more properly. Need to check if torch_dtype was specified as fp16 also
-        # assert train_args.fp16, "need to run in fp16 mixed precision or load model in fp16"
-
-        # this is a hack to enter the enable_grads part of the code in 
-        # prepare_model_for_kbit_training below
-
-        setattr(model, "is_loaded_in_4bit", True)
-        setattr(model, "quantization_method", 'gptq')
-
-        # we need to call this here, because it is supposed to be called inside 
-        # SFTTRainer, but because we pass a already PEFTed model into Trainer, 
-        # it will skip that part of the code
-        from peft import prepare_model_for_kbit_training
+        # call the prepare_model_for_kbit_training. This will no longer be called
+        # inside SFTTrainer, because we eventually return None for the peft_config.
         model = prepare_model_for_kbit_training(
-            model,
-            use_gradient_checkpointing=train_args.gradient_checkpointing,
+            model, use_gradient_checkpointing=train_args.gradient_checkpointing,
             gradient_checkpointing_kwargs=train_args.gradient_checkpointing_kwargs,
         )
 
-        # PEFT Installation
-        return get_gptq_peft_model(
+        # These functions need to replaced due to some incompatibliites 
+        # with newer PEFT packages.
+        # - on augmentation we call auto_gptq.utils.peft_utils.get_gptq_peft_model
+        # - this internally calls peft.utils.other.get_peft_model
+        # - however the problem is that peft API moves very fast, and there are incompatiblities
+        # 
+        # During peft wrapping there are two key operations
+        # 1. LoraModel._create_new_module is called to create a LoraLinear layer that is
+        #    compatible with the base layer. For quantized base layers, the LoraLinear
+        #    may be different.
+        # 2. GPTQLoraModel._replace_module to replace the existing Linear with the LoraLinear.
+        #    Also move to device (which may depend on how base layer is implemented)
+
+        # NOTE: GPTQLoraModel inherits from LoraModel, and the _create_new_module method is called
+        # on the parent. Hence _create_new_module is patched on the parent
+
+        # FIXME: 
+        # 1. investigate using BaseGPTQForCausalLM.make_sure_compatible_with_peft
+        #    to see if we can get around the patching
+
+        _old_create_new_module = LoraModel
+        _old_replace_module = GPTQLoraModel._replace_module
+        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
+        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
+
+        # Install GPTQ adapters using the AutoGPTQ package (with the above patches)
+        model = get_gptq_peft_model(
             model, 
-            peft_config = peft_config, 
-            auto_find_all_linears=False,
-            train_mode = True,
+            peft_config=peft_config, 
+            auto_find_all_linears=peft_config.target_modules is None,
+            train_mode=True, # install adapaters for training
         )
+        modifiable_args = (None, ) # return a None for peft_config
+
+        # undo the patching for hygine
+        LoraModel._create_new_module = staticmethod(_old_create_new_module)
+        GPTQLoraModel._replace_module = MethodType(_old_replace_module, GPTQLoraModel)
+
+        return model, modifiable_args

--- a/tuning/acceleration/framework.py
+++ b/tuning/acceleration/framework.py
@@ -1,0 +1,106 @@
+
+def parse_configuration():
+    pass
+
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+from auto_gptq.utils.peft_utils import get_gptq_peft_model
+
+from transformers import TrainingArguments
+from peft import LoraConfig
+
+from types import MethodType
+from auto_gptq.utils.peft_utils import GPTQLoraModel
+from peft.tuners.lora.model import LoraModel
+
+import torch
+
+def _replace_module(self, parent_module, child_name, new_module, old_module):
+    setattr(parent_module, child_name, new_module)
+    # dispatch to correct device
+    for name, module in new_module.named_modules():
+        if "lora_" in name:
+            device = (list(old_module.parameters()) + list(old_module.buffers()))[0].device
+            module.to(device)
+
+from peft.tuners.lora.gptq import QuantLinear as PEFT_LoraLinear
+
+def _dispatch_gptq_triton(
+    target: torch.nn.Module,
+    adapter_name: str,
+    **kwargs,
+):
+    new_module = None
+    from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as triton_Qlinear
+    if isinstance(target, triton_Qlinear):
+        new_module = PEFT_LoraLinear(target, adapter_name, **kwargs)
+    return new_module
+
+# refactor!
+def _create_new_module_triton(lora_config, adapter_name, target, **kwargs):
+    return _dispatch_gptq_triton(target, adapter_name, lora_config=lora_config, **kwargs)
+
+class AccelerationFramework:
+    def __init__(self, configuration_file: str=None):
+        pass
+
+    def model_loader(self, model_name: str, **kwargs):
+        quantize_config = BaseQuantizeConfig.from_pretrained(model_name)
+        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
+        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
+
+        torch_dtype = kwargs.get('torch_dtype', torch.float32)
+
+        return AutoGPTQForCausalLM.from_quantized(
+            model_name, quantize_config = quantize_config,
+            torch_dtype=torch_dtype,
+            use_marlin = False,
+            disable_exllama = True,
+            # warmup_triton = True,
+            warmup_triton= False, # disable for now, because it will try to run the warmup while on CPU
+            use_tritonv2 = True,
+            trainable = True,
+        )
+
+    @property
+    def requires_custom_loading(self):
+        return True
+
+    @property
+    def requires_agumentation(self):
+        return True
+
+    def augmentation(
+        self, 
+        model, 
+        accelerator,
+        train_args: TrainingArguments, 
+        peft_config: LoraConfig,
+    ):
+        assert peft_config is not None, "need peft_config to install PEFT adapters"
+
+        # FIXME: handle this more properly. Need to check if torch_dtype was specified as fp16 also
+        # assert train_args.fp16, "need to run in fp16 mixed precision or load model in fp16"
+
+        # this is a hack to enter the enable_grads part of the code in 
+        # prepare_model_for_kbit_training below
+
+        setattr(model, "is_loaded_in_4bit", True)
+        setattr(model, "quantization_method", 'gptq')
+
+        # we need to call this here, because it is supposed to be called inside 
+        # SFTTRainer, but because we pass a already PEFTed model into Trainer, 
+        # it will skip that part of the code
+        from peft import prepare_model_for_kbit_training
+        model = prepare_model_for_kbit_training(
+            model,
+            use_gradient_checkpointing=train_args.gradient_checkpointing,
+            gradient_checkpointing_kwargs=train_args.gradient_checkpointing_kwargs,
+        )
+
+        # PEFT Installation
+        return get_gptq_peft_model(
+            model, 
+            peft_config = peft_config, 
+            auto_find_all_linears=False,
+            train_mode = True,
+        )

--- a/tuning/acceleration/framework.py
+++ b/tuning/acceleration/framework.py
@@ -1,172 +1,102 @@
-
-def parse_configuration():
-    pass
-
-
-from transformers import TrainingArguments
-from peft import LoraConfig, prepare_model_for_kbit_training
-
-from types import MethodType
-
-from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
-from auto_gptq.utils.peft_utils import get_gptq_peft_model
-from auto_gptq.utils.peft_utils import GPTQLoraModel
-from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as triton_Qlinear
-
-from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
-from peft.tuners.lora.model import LoraModel
-
-from typing import Tuple
-
 import torch
 
-def _replace_module(self, parent_module, child_name, new_module, old_module):
+import yaml
+from typing import Optional, List, Dict, Tuple
 
-    # replace the lora linear
-    setattr(parent_module, child_name, new_module)
+from transformers import TrainingArguments, PreTrainedModel
+from transformers.utils.import_utils import _is_package_available
+from peft import LoraConfig
 
-    # dispatch to correct device 
-    # FIXME: refactor
-    for name, module in new_module.named_modules():
-        if "lora_" in name:
-            device = (list(old_module.parameters()) + list(old_module.buffers()))[0].device
-            module.to(device)
+KEY_PLUGINS = 'plugins'
 
-# def _dispatch_lora_linear_for_gptq(
-def _create_new_module_triton(
-    lora_config: LoraConfig,
-    adapter_name: str,
-    target: torch.nn.Module,
-    **kwargs,
-):
-    # if the base layer module matches a supported class, dispatch the lora linear
-    # to be installed
-    new_module = None
-    if isinstance(target, triton_Qlinear):
-        new_module = LoraLinearGPTQ(target, adapter_name, lora_config=lora_config, **kwargs)
+from .plugins import AccelerationPlugin, INSTALLED_PLUGINS_CLASSES
 
-    # if module cannot be found, return None which results in a raise in the call-stack
-    return new_module
+def check_plugin_packages(plugin: AccelerationPlugin):
+    if plugin.require_packages is None:
+        return True # passthrough
+
+    for package_name in plugin.require_packages:
+        _is_package_available(package_name)
 
 class AccelerationFramework:
-    def __init__(self, configuration_file: str=None):
 
-        # Currently we only support the triton_v2 kernel, so there is nothing
-        # much else to configure
-        pass
+    active_plugins: Dict[str, AccelerationPlugin] = dict()
+    plugins_require_custom_loading: List = list()
+
+    def __init__(self, configuration_file: Optional[str]=None):
+
+        with open(configuration_file, "r") as f:
+            contents = yaml.safe_load(f)
+        
+        # pepare the plugin configurations
+        plugin_configs = { k:v for k,v in contents[KEY_PLUGINS].items() }
+
+        for cls in INSTALLED_PLUGINS_CLASSES:
+            selected_configs = {
+                k: plugin_configs[k]
+                for k in cls.configuration_keys if k in plugin_configs
+            }
+
+            # then the model is to be installed
+            if len(selected_configs) > 0:
+                # get the plugin
+                plugin_name = str(cls.__name__)
+                plugin = cls(selected_configs)
+
+                # check plugin
+                check_plugin_packages(plugin)
+
+                # install plugin
+                self.active_plugins[plugin_name] = plugin
+                if plugin.requires_custom_loading:
+                    self.plugins_require_custom_loading.append(plugin_name)
+
+        if len(self.active_plugins) == 0:
+            raise ValueError(f"plugins must be selected from \'{[x.__name__ for x in INSTALLED_PLUGINS_CLASSES]}\'")
+
+        assert len(self.plugins_require_custom_loading) <= 1, \
+            f"can load at most 1 plugin with custom model loading, but have \'{self.plugins_require_custom_loading}\'"
 
     def model_loader(self, model_name: str, **kwargs):
 
-        # Currently we allow only a quantized checkpoint to be loaded, we do not
-        # implement the quantization process here. 
-        #
-        # The quantization process is used to convert a non-quantized checkpoint
-        # (provided in model_name) into a quantized one. This entails
-        # 1. providing a BaseQuantizeConfig with the appropriate quantization settings
-        # 2. calling BaseGPTQForCausalLM.quantize to run the quantization algorithm (may take time, e.g. hours)
-        # 3. calling BaseGPTQForCausalLM.save_pretrained to save a quantized checkpoint
-        # 
-        # The reasons for not implementing the flow at this point are.
-        # 1. The quantization can take very long for large models. As such, it is more appropriate
-        #    to run it once outside of training, and save the checkpoint to be used for multiple runs.
-        # 2. Requires some API changes to point to where the quantized checkpoint should be saved.
-        #    Can be confusing to the user since it will be different from model_name
+        if len(self.plugins_require_custom_loading) == 0:
+            raise NotImplementedError("None of the loaded plugins")
 
-        # NOTE: there will be a warning that can be ignored
-        # "WARNING - QuantLinear with the exllama backend not does support the trainable mode yet, switching to cuda/cuda_old/triton backend."
-
-        # assume model_name points to a quantized checkpoint. Thus we load the quantization
-        # config directly from the checkpoint.
-        quantize_config = BaseQuantizeConfig.from_pretrained(model_name)
-
-        # get additional parameters
-        torch_dtype = kwargs.get('torch_dtype', torch.float32)
-        low_cpu_mem_usage = kwargs.get('low_cpu_mem_usage', False)
-
-        model = AutoGPTQForCausalLM.from_quantized(
-            model_name, 
-            quantize_config=quantize_config,
-            torch_dtype=torch_dtype,
-            low_cpu_mem_usage=low_cpu_mem_usage,
-            use_marlin=False, # disable, cannot be used for training (no forward+backward)
-            disable_exllama=True, # disable, cannot be used for training (no backward)
-            warmup_triton=False, # disable for now, because it will try to run the warmup while on CPU
-            use_tritonv2=True,
-            trainable=True, # only support trainable mode
-        )
-
-        # these will be properly set since it is not loaded using from_pretrained
-        # - so, set them here. 
-        # - in particular "is_loaded_in_4bit" will be checked in prepare_model_for_kbit_training
-        #   and there is a section of code that will be skipped if not set.
-        setattr(model, "is_loaded_in_4bit", True)
-        setattr(model, "quantization_method", 'gptq')
-        return model
-
-    @property
-    def requires_custom_loading(self):
-        return True
-
-    @property
-    def requires_agumentation(self):
-        return True
+        # otherwise there should be exactly 1
+        plugin_name = self.plugins_require_custom_loading[0]
+        return self.active_plugins[plugin_name].model_loader(model_name, **kwargs)
 
     def augmentation(
         self, 
-        model, 
+        model: PreTrainedModel,
         train_args: TrainingArguments,
         modifiable_args: Tuple[LoraConfig],
     ):
-        peft_config, = modifiable_args # unpack modifiable args
+        model_archs = set(model.config.architectures) # get the config
 
-        # some assertions
-        assert peft_config is not None, "need peft_config to install PEFT adapters"
-        assert model.dtype == torch.float16 or train_args.fp16,\
-             "need to run in fp16 mixed precision or load model in fp16"
+        # NOTE: this assumes that augmentation order does not matter
+        for plugin_name, plugin in self.active_plugins.items():
 
-        # call the prepare_model_for_kbit_training. This will no longer be called
-        # inside SFTTrainer, because we eventually return None for the peft_config.
-        model = prepare_model_for_kbit_training(
-            model, use_gradient_checkpointing=train_args.gradient_checkpointing,
-            gradient_checkpointing_kwargs=train_args.gradient_checkpointing_kwargs,
-        )
+            # check the model arcs at augmentation 
+            if (
+                plugin.restricted_model_archs and
+                not any([x in model_archs for x in plugin.restricted_model_archs])
+            ):
+                raise ValueError(
+                    f'model archs \'{model_archs}\' not supported for \'{plugin_name}\''
+                )
 
-        # These functions need to replaced due to some incompatibliites 
-        # with newer PEFT packages.
-        # - on augmentation we call auto_gptq.utils.peft_utils.get_gptq_peft_model
-        # - this internally calls peft.utils.other.get_peft_model
-        # - however the problem is that peft API moves very fast, and there are incompatiblities
-        # 
-        # During peft wrapping there are two key operations
-        # 1. LoraModel._create_new_module is called to create a LoraLinear layer that is
-        #    compatible with the base layer. For quantized base layers, the LoraLinear
-        #    may be different.
-        # 2. GPTQLoraModel._replace_module to replace the existing Linear with the LoraLinear.
-        #    Also move to device (which may depend on how base layer is implemented)
-
-        # NOTE: GPTQLoraModel inherits from LoraModel, and the _create_new_module method is called
-        # on the parent. Hence _create_new_module is patched on the parent
-
-        # FIXME: 
-        # 1. investigate using BaseGPTQForCausalLM.make_sure_compatible_with_peft
-        #    to see if we can get around the patching
-
-        _old_create_new_module = LoraModel
-        _old_replace_module = GPTQLoraModel._replace_module
-        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
-        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
-
-        # Install GPTQ adapters using the AutoGPTQ package (with the above patches)
-        model = get_gptq_peft_model(
-            model, 
-            peft_config=peft_config, 
-            auto_find_all_linears=peft_config.target_modules is None,
-            train_mode=True, # install adapaters for training
-        )
-        modifiable_args = (None, ) # return a None for peft_config
-
-        # undo the patching for hygine
-        LoraModel._create_new_module = staticmethod(_old_create_new_module)
-        GPTQLoraModel._replace_module = MethodType(_old_replace_module, GPTQLoraModel)
+            if plugin.requires_agumentation:
+                model, modifiable_args = plugin.augmentation(
+                    model, train_args, modifiable_args=modifiable_args
+                )
 
         return model, modifiable_args
+
+    @property
+    def requires_custom_loading(self):
+        return len(self.plugins_require_custom_loading) > 0
+
+    @property
+    def requires_agumentation(self):
+        return any([x.requires_agumentation for x in self.active_plugins.values()])

--- a/tuning/acceleration/plugins/__init__.py
+++ b/tuning/acceleration/plugins/__init__.py
@@ -1,4 +1,4 @@
-from .framework_plugin import AccelerationPlugin
+from .framework_plugin import AccelerationPlugin, AccelerationPluginInitError
 from .framework_plugin_autogptq import AutoGPTQAccelerationPlugin
 
 INSTALLED_PLUGINS_CLASSES = [

--- a/tuning/acceleration/plugins/__init__.py
+++ b/tuning/acceleration/plugins/__init__.py
@@ -1,0 +1,6 @@
+from .framework_plugin import AccelerationPlugin
+from .framework_plugin_autogptq import AutoGPTQAccelerationPlugin
+
+INSTALLED_PLUGINS_CLASSES = [
+    AutoGPTQAccelerationPlugin
+]

--- a/tuning/acceleration/plugins/framework_plugin.py
+++ b/tuning/acceleration/plugins/framework_plugin.py
@@ -1,0 +1,38 @@
+import torch
+from typing import List, Dict, Tuple, Optional, Set
+from transformers import TrainingArguments
+from peft import LoraConfig
+
+class AccelerationPlugin:
+
+    configuration_keys: List[str] = []
+    restricted_model_archs: Optional[Set] = None
+    require_packages: Optional[Set] = None
+
+    def __init__(self, configurations: List[Dict]):
+
+        # will pass in a list of dictionaries keyed by "configuration_keys"
+        # to be used for initialization
+        pass
+
+    @property
+    def requires_custom_loading(self):
+        return False
+
+    @property
+    def requires_agumentation(self):
+        return False
+
+    def model_loader(self, model_name: str, **kwargs):
+        raise NotImplementedError
+
+    def augmentation(
+        self, 
+        model: torch.nn.Module, 
+        train_args: TrainingArguments,
+        modifiable_args: Tuple[LoraConfig],
+    ):
+        raise NotImplementedError
+
+    def callbacks(self):
+        return []

--- a/tuning/acceleration/plugins/framework_plugin.py
+++ b/tuning/acceleration/plugins/framework_plugin.py
@@ -1,5 +1,5 @@
 import torch
-from typing import List, Dict, Tuple, Optional, Set
+from typing import List, Dict, Tuple, Optional, Set, Any
 from transformers import TrainingArguments
 from peft import LoraConfig
 
@@ -9,11 +9,11 @@ class AccelerationPlugin:
     restricted_model_archs: Optional[Set] = None
     require_packages: Optional[Set] = None
 
-    def __init__(self, configurations: List[Dict]):
+    def __init__(self, configurations: Dict[str, Dict]):
 
         # will pass in a list of dictionaries keyed by "configuration_keys"
         # to be used for initialization
-        pass
+        self.configurations = configurations
 
     @property
     def requires_custom_loading(self):
@@ -36,3 +36,27 @@ class AccelerationPlugin:
 
     def callbacks(self):
         return []
+
+    def _get_config_value(self, key: str):
+        t = self.configurations
+        for k in key.split('.'):
+            t = t[k]
+        return t
+
+    def _check_config_in_values(
+        self, key: str, values: List[Any], message: str = None
+    ):
+        t = self.configurations
+        for k in key.split('.'):
+            t = t[k]
+        if t not in values:
+            raise AccelerationPluginInitError(
+                message if message is not None else
+                f"\'{key}\' must be in \'{values}\'"
+            )
+
+    def _check_config_equal(self, key: str, value: Any, **kwargs):
+        return self._check_config_in_values(key, [value], **kwargs)
+
+class AccelerationPluginInitError(Exception):
+    pass

--- a/tuning/acceleration/plugins/framework_plugin_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_autogptq.py
@@ -1,0 +1,179 @@
+
+def parse_configuration():
+    pass
+
+
+from transformers import TrainingArguments
+from peft import LoraConfig, prepare_model_for_kbit_training
+
+from types import MethodType
+
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+from auto_gptq.utils.peft_utils import get_gptq_peft_model
+from auto_gptq.utils.peft_utils import GPTQLoraModel
+from auto_gptq.nn_modules.qlinear.qlinear_tritonv2 import QuantLinear as triton_Qlinear
+
+from peft.tuners.lora.gptq import QuantLinear as LoraLinearGPTQ
+from peft.tuners.lora.model import LoraModel
+
+from typing import Tuple, List, Dict
+
+from tuning.acceleration.plugins.framework_plugin import AccelerationPlugin
+
+import torch
+
+def _replace_module(self, parent_module, child_name, new_module, old_module):
+
+    # replace the lora linear
+    setattr(parent_module, child_name, new_module)
+
+    # dispatch to correct device 
+    # FIXME: refactor
+    for name, module in new_module.named_modules():
+        if "lora_" in name:
+            device = (list(old_module.parameters()) + list(old_module.buffers()))[0].device
+            module.to(device)
+
+# def _dispatch_lora_linear_for_gptq(
+def _create_new_module_triton(
+    lora_config: LoraConfig,
+    adapter_name: str,
+    target: torch.nn.Module,
+    **kwargs,
+):
+    # if the base layer module matches a supported class, dispatch the lora linear
+    # to be installed
+    new_module = None
+    if isinstance(target, triton_Qlinear):
+        new_module = LoraLinearGPTQ(target, adapter_name, lora_config=lora_config, **kwargs)
+
+    # if module cannot be found, return None which results in a raise in the call-stack
+    return new_module
+
+class AutoGPTQAccelerationPlugin(AccelerationPlugin):
+    
+    configuration_keys = ['peft']
+    require_packages = ['auto_gptq']
+
+    def __init__(self, configurations: List[Dict]):
+
+        # Currently we only support the triton_v2 kernel, so there is nothing
+        # much else to configure
+        pass
+
+    def model_loader(self, model_name: str, **kwargs):
+
+        # Currently we allow only a quantized checkpoint to be loaded, we do not
+        # implement the quantization process here. 
+        #
+        # The quantization process is used to convert a non-quantized checkpoint
+        # (provided in model_name) into a quantized one. This entails
+        # 1. providing a BaseQuantizeConfig with the appropriate quantization settings
+        # 2. calling BaseGPTQForCausalLM.quantize to run the quantization algorithm (may take time, e.g. hours)
+        # 3. calling BaseGPTQForCausalLM.save_pretrained to save a quantized checkpoint
+        # 
+        # The reasons for not implementing the flow at this point are.
+        # 1. The quantization can take very long for large models. As such, it is more appropriate
+        #    to run it once outside of training, and save the checkpoint to be used for multiple runs.
+        # 2. Requires some API changes to point to where the quantized checkpoint should be saved.
+        #    Can be confusing to the user since it will be different from model_name
+
+        # NOTE: there will be a warning that can be ignored
+        # "WARNING - QuantLinear with the exllama backend not does support the trainable mode yet, switching to cuda/cuda_old/triton backend."
+
+        # assume model_name points to a quantized checkpoint. Thus we load the quantization
+        # config directly from the checkpoint.
+        quantize_config = BaseQuantizeConfig.from_pretrained(model_name)
+
+        # get additional parameters
+        torch_dtype = kwargs.get('torch_dtype', torch.float32)
+        low_cpu_mem_usage = kwargs.get('low_cpu_mem_usage', False)
+
+        model = AutoGPTQForCausalLM.from_quantized(
+            model_name, 
+            quantize_config=quantize_config,
+            torch_dtype=torch_dtype,
+            low_cpu_mem_usage=low_cpu_mem_usage,
+            use_marlin=False, # disable, cannot be used for training (no forward+backward)
+            disable_exllama=True, # disable, cannot be used for training (no backward)
+            warmup_triton=False, # disable for now, because it will try to run the warmup while on CPU
+            use_tritonv2=True,
+            trainable=True, # only support trainable mode
+        )
+
+        # these will be properly set since it is not loaded using from_pretrained
+        # - so, set them here. 
+        # - in particular "is_loaded_in_4bit" will be checked in prepare_model_for_kbit_training
+        #   and there is a section of code that will be skipped if not set.
+        setattr(model, "is_loaded_in_4bit", True)
+        setattr(model, "quantization_method", 'gptq')
+
+        return model
+
+    @property
+    def requires_custom_loading(self):
+        return True
+
+    @property
+    def requires_agumentation(self):
+        return True
+
+    def augmentation(
+        self, 
+        model, 
+        train_args: TrainingArguments,
+        modifiable_args: Tuple[LoraConfig],
+    ):
+        peft_config, = modifiable_args # unpack modifiable args
+
+        # some assertions
+        assert peft_config is not None, "need peft_config to install PEFT adapters"
+        assert model.dtype == torch.float16 or train_args.fp16,\
+             "need to run in fp16 mixed precision or load model in fp16"
+
+        # call the prepare_model_for_kbit_training. This will no longer be called
+        # inside SFTTrainer, because we eventually return None for the peft_config.
+        model = prepare_model_for_kbit_training(
+            model, use_gradient_checkpointing=train_args.gradient_checkpointing,
+            gradient_checkpointing_kwargs=train_args.gradient_checkpointing_kwargs,
+        )
+
+        # These functions need to replaced due to some incompatibliites 
+        # with newer PEFT packages.
+        # - on augmentation we call auto_gptq.utils.peft_utils.get_gptq_peft_model
+        # - this internally calls peft.utils.other.get_peft_model
+        # - however the problem is that peft API moves very fast, and there are incompatiblities
+        # 
+        # During peft wrapping there are two key operations
+        # 1. LoraModel._create_new_module is called to create a LoraLinear layer that is
+        #    compatible with the base layer. For quantized base layers, the LoraLinear
+        #    may be different.
+        # 2. GPTQLoraModel._replace_module to replace the existing Linear with the LoraLinear.
+        #    Also move to device (which may depend on how base layer is implemented)
+
+        # NOTE: GPTQLoraModel inherits from LoraModel, and the _create_new_module method is called
+        # on the parent. Hence _create_new_module is patched on the parent
+
+        # FIXME: 
+        # 1. investigate using BaseGPTQForCausalLM.make_sure_compatible_with_peft
+        #    to see if we can get around the patching
+
+        _old_create_new_module = LoraModel
+        _old_replace_module = GPTQLoraModel._replace_module
+        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
+        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
+
+        # Install GPTQ adapters using the AutoGPTQ package (with the above patches)
+        model = get_gptq_peft_model(
+            model, 
+            peft_config=peft_config, 
+            auto_find_all_linears=peft_config.target_modules is None,
+            train_mode=True, # install adapaters for training
+        )
+        modifiable_args = (None, ) # return a None for peft_config
+
+        # undo the patching for hygine
+        LoraModel._create_new_module = staticmethod(_old_create_new_module)
+        GPTQLoraModel._replace_module = MethodType(_old_replace_module, GPTQLoraModel)
+
+        return model, modifiable_args

--- a/tuning/acceleration/plugins/framework_plugin_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_autogptq.py
@@ -55,11 +55,15 @@ class AutoGPTQAccelerationPlugin(AccelerationPlugin):
     configuration_keys = ['peft']
     require_packages = ['auto_gptq']
 
-    def __init__(self, configurations: List[Dict]):
+    def __init__(self, configurations: Dict[str, Dict]):
+        super().__init__(configurations)
 
-        # Currently we only support the triton_v2 kernel, so there is nothing
-        # much else to configure
-        pass
+        # just do checking, nothing must to configure at this point
+        # if need to configure then do something like this:
+        # self.kernel = self._get_config_value("peft.kernel")
+        self._check_config_equal(key="peft.quantization", value="auto_gptq")
+        self._check_config_equal(key="peft.kernel", value="triton_v2")
+        self._check_config_equal(key="peft.from_quantized", value=True)
 
     def model_loader(self, model_name: str, **kwargs):
 

--- a/tuning/config/configs.py
+++ b/tuning/config/configs.py
@@ -103,3 +103,15 @@ class TrainerControllerArguments:
             )
         },
     )
+
+@dataclass
+class AccelerationFrameworkArguments:
+    acceleration_framework_config_file: str = field(
+        default=None,
+        metadata={
+            "help": (
+                "Acceleration Framework configuration file (e.g acceleration_framework.yaml) \
+                    in YAML format."
+            )
+        },
+    )

--- a/tuning/sft_trainer.py
+++ b/tuning/sft_trainer.py
@@ -101,7 +101,8 @@ def train(
     peft_config: Optional[  # pylint: disable=redefined-outer-name
         Union[peft_config.LoraConfig, peft_config.PromptTuningConfig]
     ] = None,
-    trainer_controller_args: configs.TrainerControllerArguments = None,
+    trainer_controller_args: Optional[configs.TrainerControllerArguments] = None,
+    acceleration_framework_args: Optional[configs.AccelerationFrameworkArguments] = None,
 ):
     """Call the SFTTrainer
 
@@ -115,13 +116,17 @@ def train(
             The peft configuration to pass to trainer
         trainer_control_args: configs.TrainerControllerArguments \
             for controlling the training loop using policy rules
+        acceleration_framework_args: configs.AccelerationFrameworkArguments \
+            for controlling acceleration framework
     """
 
     logger = logging.get_logger("sft_trainer")
 
     framework = None
-    # TODO: check if the framework config is passed in
-    framework = AccelerationFramework()
+    if acceleration_framework_args is not None:
+        framework = AccelerationFramework(
+            acceleration_framework_args.acceleration_framework_config_file
+        )
 
     # Validate parameters
     if (not isinstance(train_args.num_train_epochs, (float, int))) or (
@@ -302,6 +307,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
             configs.DataArguments,
             configs.TrainingArguments,
             configs.TrainerControllerArguments,
+            configs.AccelerationFrameworkArguments,
             peft_config.LoraConfig,
             peft_config.PromptTuningConfig,
         )
@@ -317,6 +323,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
         data_args,
         training_args,
         trainer_controller_args,
+        acceleration_framework_args,
         lora_config,
         prompt_tuning_config,
         peft_method,
@@ -328,7 +335,7 @@ def main(**kwargs):  # pylint: disable=unused-argument
         tune_config = prompt_tuning_config
     else:
         tune_config = None
-    train(model_args, data_args, training_args, tune_config, trainer_controller_args)
+    train(model_args, data_args, training_args, tune_config, trainer_controller_args, acceleration_framework_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description of the change

This PR integrates the **acceleration framework** 
- implements `AccelerationFramework` that configures, and manages the enhancement plugins.
- implements `AccelerationPlugin`, the parent class for the enhancement plugins.
- implements `AutoGPTQAccelerationPlugin`, that integrates [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ). 
    * only the `triton_v2` kernel is integrated, because the other kernels (e.g., `exllama, marlin`) are not to be used in training as they lack suitable `autograd` implementations 


TODO:
- [x] integrate framework and configuration
- [x] integrate AutoGPTQ "triton_v2"
- [ ] write unit tests
- [ ] update optional deps

<!-- Please summarize the changes -->

### Related issue number


<!-- For example: "Closes #1234" -->

### How to verify the PR

To activate `AccelerationFramework` these are the following steps:

#### Step 1: create a YAML to configures the framework

This example activates the plugin that implements `auto_gptq` to be used for PEFT training
```yaml
plugins:
  peft:
    quantization: auto_gptq
    kernel: triton_v2
    from_quantized: True
```

#### Step2 : Run SFT Trainer script.

Run the script as usual, but (see example below):
- specify the `--acceleration_framework_config_file` key pointing to the above yaml file
- remember to ensure appropriate `dytpe`'s that the kernel supports (`triton_v2` kernel supports `float16` only) : 
    1. specifying the native dtype via `--torch_dtype`, or 
    2. specifying AMP (e.g., via `--fp16`). 
- specifying the `--peft_method lora` and the other related settings. 

```shell
python \
    tuning/sft_trainer.py \
    --training_data_path $DATA_PATH \
    --model_name_or_path mistralai/Mixtral-8x7B-Instruct-v0.1 \
    --acceleration_framework_config_file fixtures/acceleration_framework.yaml \
    --torch_dtype float16 \
    ...
    --peft_method lora \
	--r 16 --lora_alpha 16 --lora_dropout 0.1 \
    --target_modules q_proj k_proj v_proj o_proj 
```

<!-- Please provide instruction or screenshots on how to verify the PR.-->

### Was the PR tested

#### Experiments on Mixtral 8x7b

We performed experiments on a short `--max_steps 200` to validate some loss curves and train times, see below

Loss Curves
- in addition to those obtained via `sft_trainer.py` using the above commands, we also benched against a test script (`measure.py`) that was used for testing prior integration. This is done for the `autogptq_triton_v2` case only. 
   - We observe that the loss curves match up, for two learning rates (`2e-4` and `2e-5`) that was tested.
   - This gave confidence that the integration via `AccelerationFramework` works as intended

<!--
- We compared to HF integration of `bitsandbytes`, in particular loading PEFT LoRA [base weights in 4 bits](https://huggingface.co/docs/transformers/en/main_classes/quantization#transformers.BitsAndBytesConfig). We considered both `bnb_4bit_quant_type="nft"` and `"fp4"`.
   - We noted that this uses `bitsandbytes` implemenation of `Linear4bit`, [which uses `matmul_4bit`](https://github.com/TimDettmers/bitsandbytes/blob/127788a96e123bb2e95ff9dbcc78672e4849cddc/bitsandbytes/nn/modules.py#L468).
   - The difference here with the AutoGPTQ's `triton_v2` above, is that this is implemented via "fake quantization". In particular, this is [implemented via `MatMul4Bit.apply`](https://github.com/TimDettmers/bitsandbytes/blob/127788a96e123bb2e95ff9dbcc78672e4849cddc/bitsandbytes/autograd/_functions.py#L572) which is a [concatenation of a dequant and `torch.nn.linear`](https://github.com/TimDettmers/bitsandbytes/blob/127788a96e123bb2e95ff9dbcc78672e4849cddc/bitsandbytes/autograd/_functions.py#L509). 
   - Hence we observe due to possibly higher precision representation, the loss curve is slightly lower than that of AutoGPTQ `triton_v2`. 
-->

![image](https://github.com/fabianlim/fms-hf-tuning/assets/8325951/646fe595-5e56-4f0b-81ac-68d0c50842cc)



<!--

![image](https://github.com/fabianlim/fms-hf-tuning/assets/8325951/7d1b35e1-e345-407f-adbf-f40aaa55628e)
-->

We summarize the throughputs below:
- the throughputs for the integration `sft_trainer.py` and our test script `measure.py` match up well, proving the integration is correct.

<!--
- the `triton_v2` achieve much faster througputs than `bitsandbytes`'s `MatMul4Bit.apply` ,as expected since this falls back to `torch.nn.linear` which is not a native 4bit kernel.
-->

Package | Kernel | Script | Tokens /s
--|--|--|--
AutoGPTQ | `triton_v2` | `sft_trainer.py` | 1808
AutoGPTQ | `triton_v2` | `measure.py` | 1822

<!--
`bitsandbytes, "fp4"` |  None (i.e., `MatMul4Bit.apply`)   | `sft_trainer.py` | 218
`bitsandbytes, "nf4"` |  None (i.e., `MatMul4Bit.apply`)   | `sft_trainer.py` | 218
-->

<!-- Describe how PR was tested -->
- [ ] I have added >=1 unit test(s) for every new method I have added.
- [ ] I have ensured all unit tests pass