### PR TITLE
Unsloth-AutoGPTQ Plugin

### DIFF
--- a/fixtures/acceleration_framework.yaml
+++ b/fixtures/acceleration_framework.yaml
@@ -5,11 +5,15 @@ plugins:
 
     # quantization
     quantization: 
+      # Include unsloth optimizations
+      unsloth:
+        base_layer:  auto_gptq
+        kernel: triton_v2
 
       # Q-LORA using autogptq
-      auto_gptq:
-        kernel: triton_v2
-        from_quantized: True
+      # auto_gptq:
+      #   kernel: triton_v2
+      #   from_quantized: True
 
       # Q-LORA using BNB
       # bitsandbytes:

--- a/tuning/acceleration/plugins/__init__.py
+++ b/tuning/acceleration/plugins/__init__.py
@@ -3,3 +3,4 @@ from .framework_plugin import AccelerationPlugin, get_relevant_configuration_sec
 # can this be automated?
 from .framework_plugin_autogptq import AutoGPTQForCausalLM
 from .framework_plugin_bnb import BNBAccelerationPlugin
+from .framework_plugin_unsloth_autogptq import UnslothAutoGPTQAccelerationPlugin

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -40,8 +40,7 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
     restricted_model_archs = ['MixtralForCausalLM', 'LlamaForCausalLM', 'MistralForCausalLM', 'GemmaForCausalLM']
 
     '''
-    NOTE:
-    Unsloth's OSS license allows for up to 4 GPUs, will require a commercial license for larger resources
+    NOTE: unloth's LICENSE file looks like a standar Apache 2.0, but in various parts of the code, it claims to require a commercial license if used to run on more than 4 GPUs, see 
     https://github.com/unslothai/unsloth/blob/d215fd902cf28feb8abcfde2d25281d0fbf9d28c/unsloth/models/llama.py#L1140-L1143
     '''
 

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -1,0 +1,150 @@
+
+def parse_configuration():
+    pass
+
+import torch
+from transformers import TrainingArguments
+from peft import LoraConfig
+from peft.tuners.lora.model import LoraModel
+from auto_gptq.utils.peft_utils import GPTQLoraModel
+from unsloth import FastLanguageModel
+from unsloth.utils.modeling import QuantizationMethod
+from unsloth.gptq.triton.layers import GPTQuantLinear
+
+from types import MethodType
+from typing import Tuple, List, Dict
+
+from .framework_plugin import AccelerationPlugin
+from .framework_plugin_autogptq import _replace_module, LoraLinearGPTQ
+
+# def _dispatch_lora_linear_for_gptq(
+def _create_new_module_triton(
+    lora_config: LoraConfig,
+    adapter_name: str,
+    target: torch.nn.Module,
+    **kwargs,
+):
+    # if the base layer module matches a supported class, dispatch the lora linear
+    # to be installed
+    new_module = target
+    if (
+        isinstance(target, GPTQuantLinear)
+    ):
+        new_module = LoraLinearGPTQ(target, adapter_name, **kwargs)
+    # if module cannot be found, return None which results in a raise in the call-stack
+    return new_module
+
+class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
+    
+    require_packages = ['auto_gptq', 'unsloth']
+    restricted_model_archs = ['MixtralForCausalLM', 'LlamaForCausalLM', 'MistralForCausalLM', 'GemmaForCausalLM']
+
+    def __init__(self, configurations: Dict[str, Dict]):
+        super().__init__(configurations)
+
+        # just do checking, nothing must to configure at this point
+        # if need to configure then do something like this:
+        # self.kernel = self._get_config_value("peft.kernel")
+        self._check_config_equal(key="peft.quantization", value="unsloth")
+        self._check_config_equal(key="peft.quantization.unsloth.base_layer", value="auto_gptq")
+        self._check_config_equal(key="peft.quantization.unsloth.kernel", value="triton_v2")
+
+    def model_loader(self, model_name: str, **kwargs):
+        # 1. Load the gptq base model through unsloth FastLanguageModel
+        model, _ = FastLanguageModel.from_pretrained(
+            model_name,
+            quantization_method=QuantizationMethod.GPTQ,
+            device_map="auto",
+        )
+
+        # 2. Depending on the model, replace appropriate CUDA kernel with TritonV2 kernel 
+        if model.config.model_type == 'mixtral':
+            from auto_gptq.nn_modules.qlinear.qlinear_cuda_old import (
+                QuantLinear as QuantLinearCuda,
+            )                
+        else:
+            from auto_gptq.nn_modules.qlinear.qlinear_cuda import (
+                QuantLinear as QuantLinearCuda,
+            )
+        GPTQuantLinear.inject_to_model(
+            model, target_module_type=QuantLinearCuda
+        )
+
+        return model
+
+    @property
+    def requires_custom_loading(self):
+        return True
+
+    @property
+    def requires_agumentation(self):
+        return True
+
+    def augmentation(
+        self, 
+        model, 
+        train_args: TrainingArguments,
+        modifiable_args: Tuple[LoraConfig],
+    ):
+        peft_config, = modifiable_args # unpack modifiable args
+
+        # some assertions
+        assert peft_config is not None, "need peft_config to install PEFT adapters"
+        assert model.dtype == torch.float16 or train_args.fp16,\
+             "need to run in fp16 mixed precision or load model in fp16"
+        peft_kwargs = peft_config.to_dict()
+        assert peft_kwargs['lora_dropout'] == 0, "Unsloth Fused Attention requires lora_dropout argument to be set to 0"
+
+        peft_kwargs.pop('task_type')
+
+        # These functions need to replaced due to some incompatibliites 
+        # with newer PEFT packages.
+        # - on augmentation we call auto_gptq.utils.peft_utils.get_gptq_peft_model
+        # - this internally calls peft.utils.other.get_peft_model
+        # - however the problem is that peft API moves very fast, and there are incompatiblities
+        # 
+        # During peft wrapping there are two key operations
+        # 1. LoraModel._create_new_module is called to create a LoraLinear layer that is
+        #    compatible with the base layer. For quantized base layers, the LoraLinear
+        #    may be different.
+        # 2. GPTQLoraModel._replace_module to replace the existing Linear with the LoraLinear.
+        #    Also move to device (which may depend on how base layer is implemented)
+
+        # NOTE: GPTQLoraModel inherits from LoraModel, and the _create_new_module method is called
+        # on the parent. Hence _create_new_module is patched on the parent
+
+        # FIXME: 
+        # 1. investigate using BaseGPTQForCausalLM.make_sure_compatible_with_peft
+        #    to see if we can get around the patching
+
+        _old_create_new_module = LoraModel
+        _old_replace_module = GPTQLoraModel._replace_module
+        LoraModel._create_new_module = staticmethod(_create_new_module_triton)
+        GPTQLoraModel._replace_module = MethodType(_replace_module, GPTQLoraModel)
+
+        # In the unsloth implementation, the prepare_model_for_kbit_training get_peft_model is called 
+        # inside `FastLanguageModel.get_peft_model`
+        if model.config.model_type == 'mixtral':
+            from unsloth.models.mixtral import FastMixtralModel
+            _lib = FastMixtralModel
+        else:
+            _lib = FastLanguageModel
+      
+        model = _lib.get_peft_model(
+            model,
+            use_gradient_checkpointing=train_args.gradient_checkpointing,
+            **peft_kwargs,
+        )
+        modifiable_args = (None, ) # return a None for peft_config
+
+        # undo the patching for hygine
+        LoraModel._create_new_module = staticmethod(_old_create_new_module)
+        GPTQLoraModel._replace_module = MethodType(_old_replace_module, GPTQLoraModel)
+
+        return model, modifiable_args
+
+# register
+AccelerationPlugin.register_plugin(
+    UnslothAutoGPTQAccelerationPlugin,
+    configuration_and_paths=["peft.quantization.unsloth"], 
+)

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -58,7 +58,6 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
         model, _ = FastLanguageModel.from_pretrained(
                 model_name,
                 dtype=torch_dtype,
-                device_map="auto",
                 quantization_method=QuantizationMethod.GPTQ,
             )
 

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -58,6 +58,9 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
         )
 
         # 2. Depending on the model, replace appropriate CUDA kernel with TritonV2 kernel 
+        # - `FastLanguageModel` above will load a "default" cuda linear kernel. 
+        # - the idea is to load the appropriate "default" kernel (for each model), then follow up with an injection
+        #.  via the `inject_to_model(..., target_module_type=DefaultKernel)` method.
         if model.config.model_type == 'mixtral':
             from auto_gptq.nn_modules.qlinear.qlinear_cuda_old import (
                 QuantLinear as QuantLinearCuda,

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -1,6 +1,4 @@
 
-def parse_configuration():
-    pass
 
 import torch
 from transformers import TrainingArguments

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -54,7 +54,7 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
 
     def model_loader(self, model_name: str, **kwargs):
         # 1. Load the gptq base model through unsloth FastLanguageModel
-        torch_dtype = kwargs.get('torch_dtype', torch.float16)
+        torch_dtype = kwargs.get('torch_dtype', torch.float32)
         model, _ = FastLanguageModel.from_pretrained(
                 model_name,
                 dtype=torch_dtype,

--- a/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
+++ b/tuning/acceleration/plugins/framework_plugin_unsloth_autogptq.py
@@ -90,12 +90,9 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
 
         # some assertions
         assert peft_config is not None, "need peft_config to install PEFT adapters"
+        assert peft_config.lora_dropout == 0, "Unsloth Fused Attention requires lora_dropout argument to be set to 0"
         assert model.dtype == torch.float16 or train_args.fp16,\
              "need to run in fp16 mixed precision or load model in fp16"
-        peft_kwargs = peft_config.to_dict()
-        assert peft_kwargs['lora_dropout'] == 0, "Unsloth Fused Attention requires lora_dropout argument to be set to 0"
-
-        peft_kwargs.pop('task_type')
 
         # These functions need to replaced due to some incompatibliites 
         # with newer PEFT packages.
@@ -133,7 +130,7 @@ class UnslothAutoGPTQAccelerationPlugin(AccelerationPlugin):
         model = _lib.get_peft_model(
             model,
             use_gradient_checkpointing=train_args.gradient_checkpointing,
-            **peft_kwargs,
+            func(**{k:v for k,v in peft_config.to_dict() if k != 'task_type'}),
         )
         modifiable_args = (None, ) # return a None for peft_config
 


### PR DESCRIPTION
<!-- Thank you for the contribution! -->

### Description

Things to document
- ~~license issue~~
- ~~only supports dropout == 0~~
- has a dependency on optimum that we should get rid off. Also has a dependeny on xformers.
- ~~seems that quantization config not properly propagated down into `FastLanguageModel`~~
- document that we need to use fp16

<!-- Please summarize the changes -->
This PR introduces a new plugin to `tuning/acceleration/plugins` that provides the following triton optimizations in addition to the AutoGPTQ TritonV2 base layer.

1. Loss
2. LayerNorm
3. RoPE Embeddings
4. Fused Attention

#### NOTE:

1. Unsloth requires lora_dropout to be set to 0 for fast patching. if lora_config.dropout > 0, unsloth will skip replacing attention modules with fast modules.
2. Unsloth's OSS license allows for up to 4 GPUs, will require a commercial license for larger resources https://github.com/unslothai/unsloth/blob/d215fd902cf28feb8abcfde2d25281d0fbf9d28c/unsloth/models/llama.py#L1140-L1143

### Custom Dependencies
#### 1. Unsloth 
Unsloth has a dependency on the xformers library that will require a specific tag corresponding to the user's installation environment (cuda version, pytorch version etc.) 
Refer to Installation Instructions in [Unsloth](https://github.com/unslothai/unsloth) `README.md` for more information
  
EXAMPLE: `pip install git+https://$GHE_REPO/unsloth.git@dev .[cu121_ampere_torch220]`

#### 2. [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ.git) (assumed already installed)


### Reproducibility
```
python \
    tuning/sft_trainer.py \
    --training_data_path $DATA_PATH \
    --model_name_or_path TheBloke/Mixtral-8x7B-Instruct-v0.1-GPTQ \
    --acceleration_framework_config_file fixtures/acceleration_framework.yaml \
    --output_dir ./results \
    --num_train_epochs 1 \
    --per_device_train_batch_size 4 \
    --per_device_eval_batch_size 1 \
    --gradient_accumulation_steps 1 \
    --gradient_checkpointing True \
    --torch_dtype float16 \
    --fp16 \
    --learning_rate 2e-5 \
    --weight_decay 0. \
    --warmup_ratio 0. \
    --lr_scheduler_type "linear" \
    --logging_strategy 'steps' \
    --logging_steps 10 \
    --include_tokens_per_second \
    --packing True \
    --use_flash_attn False \
    --response_template "\n### Response:" \
    --dataset_text_field "output" \
    --peft_method lora \
    --evaluation_strategy "no" \
    --save_strategy "no" \
    --max_steps 200 \
    --target_modules q_proj k_proj v_proj o_proj \
    --r 16 \
    --lora_dropout 0 \
    --lora_alpha 16
```

### Tests

A test was carried out to show the similarity of throughput and loss between the new plugin to FMS and the custom unsloth script. 
* Optimized Loss, LayerNorm and RoPE embeddings
* Fused LoRA Operations with Q, K, V and O in the Attention Module
* Note that there are no fused LoRA operations in the MOE blocks of Mixtral in the following examples.

<img src="https://github.com/fabianlim/fms-hf-tuning/assets/165894159/e7e40036-aed5-421b-9fa0-adac3d41a985"  height="500" width="800"/>

<img src="https://github.com/fabianlim/fms-hf-tuning/assets/165894159/ff108fcc-0a7b-4a92-b281-6565bce35c35"  height="500" width="800"/>

